### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository formerly hosted Sage Bionetworks' Staging R Archive Network - it is now deprecated in favor of http://staging-ran.synapse.org/
+
 # Sage Bionetworks Staging R Archive Network
 
 This is the Sage Bionetworks Staging R Archive Network (Staging-RAN) - a CRAN-like repository for R packages published by Sage Bionetworks.


### PR DESCRIPTION
This repository formerly hosted Sage R packages via GitHub pages but is now deprecated in favor of the s3 based http://staging-ran.synapse.org.

The repo should be archived.